### PR TITLE
Fix challenge cover image storage key

### DIFF
--- a/lib/data/services/challenge_service.dart
+++ b/lib/data/services/challenge_service.dart
@@ -30,7 +30,8 @@ class ChallengeService {
         'isPublic': challenge.isPublic,
         'category': challenge.category,
         'maxParticipants': challenge.maxParticipants,
-        'coverImage': coverImageUrl,
+        // Store the URL for the uploaded cover image
+        'coverImageUrl': coverImageUrl,
         'emoji': challenge.emoji,
         'status': challenge.status.toString(),
         'rules': challenge.rules,


### PR DESCRIPTION
## Summary
- fix challenge service key name when saving cover image URL

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ed8ee3bb08328bc44868623da649e